### PR TITLE
Bug fixed: Invalid token bug, when user logs in, at first 

### DIFF
--- a/client/src/components/anlytics/chart/CategoryChart.tsx
+++ b/client/src/components/anlytics/chart/CategoryChart.tsx
@@ -23,8 +23,6 @@ export default function CategoryChart({ selectedDate }: Props) {
     },
   );
 
-  console.log(selectedDate);
-
   const dataForPie = {
     labels: historyData?.map((el) => el.categoryName),
     datasets: [

--- a/client/src/components/anlytics/history/HistoryViewWrapper.tsx
+++ b/client/src/components/anlytics/history/HistoryViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation } from 'react-query';
 import styled from 'styled-components';
 import Modal from '../../UI/Modal';
 import HistoryCardContainer from './HistoryCardContainer';
@@ -63,8 +63,6 @@ export default function HistoryViewWrapper({
     label: '',
     amount: '',
   });
-
-  // console.log(dateKeystroke);
 
   useEffect(() => {
     if (pickedData.type === 'income')

--- a/client/src/lib/api/account.ts
+++ b/client/src/lib/api/account.ts
@@ -6,7 +6,7 @@ export const getAllAccount = async (): Promise<
 > => {
   const { data } = await Axios.get<GetAllAccountOutput>('/acct/getall');
   if (!data.ok) {
-    console.log(data.error);
+    alert(data.error);
   }
   console.log(data.data);
   return data.data;

--- a/client/src/lib/api/category.ts
+++ b/client/src/lib/api/category.ts
@@ -8,7 +8,7 @@ export const getAllCategories = async (): Promise<
     '/category/getAllCategories',
   );
   if (!data.ok) {
-    console.log(data.error);
+    alert(data.error);
   }
   console.log(data.data);
   return data.data;

--- a/client/src/lib/api/history.ts
+++ b/client/src/lib/api/history.ts
@@ -15,10 +15,7 @@ export const fetchHistoryAPI = async (
   const { data } = await Axios.get<FetchHistoryOutput>(
     `/transaction/history?year=${fetchHistoryInput.year}&month=${fetchHistoryInput.month}`,
   );
-  if (!data.ok) {
-    console.log(data.error);
-    alert(data.error);
-  }
+  if (!data.ok) alert(data.error);
   return data.data;
 };
 

--- a/client/src/lib/api/transaction.ts
+++ b/client/src/lib/api/transaction.ts
@@ -1,4 +1,4 @@
-import Axios from '../defaultClient';
+import Axios, { source } from '../defaultClient';
 import { CoreOutput } from '../CoreOutput';
 import { AxiosResponse } from 'axios';
 import {
@@ -37,10 +37,16 @@ export const deleteTransaction = async (
   });
 };
 
-export const getPendingTransactionAPI = async (): Promise<GetPendingTransactionData> => {
+export const getPendingTransactionAPI = async (): Promise<
+  GetPendingTransactionData | undefined
+> => {
   const { data } = await Axios.get<GetPendingTransactionOutput>(
     '/transaction/getPending',
+    {
+      cancelToken: source.token,
+    },
   );
+
   if (!data.ok) {
     alert(data.error);
   }
@@ -54,4 +60,3 @@ export const ReceivePendingTransactionAPI = async (
     ...receivePendingTransactionInput,
   });
 };
-

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const TOKEN = 'TOKEN';

--- a/client/src/lib/defaultClient.ts
+++ b/client/src/lib/defaultClient.ts
@@ -1,13 +1,24 @@
-import axios, { AxiosInstance } from 'axios';
-import { TOKEN } from '../hooks/useLogin';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { TOKEN } from './constants';
 
-const token = localStorage.getItem(TOKEN);
+const CancelToken = axios.CancelToken;
+export const source = CancelToken.source();
 
-const Axios: AxiosInstance = axios.create({
+const axiosInstance: AxiosInstance = axios.create({
   baseURL: 'https://mad-salad.herokuapp.com',
   headers: {
-    authorization: token,
+    Authorization: localStorage.getItem(TOKEN),
   },
+  timeout: 6000,
 });
 
-export default Axios;
+axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
+  if (config.url === '/auth/login') return config;
+  if (!config.headers.Authorization) {
+    source.cancel('Request cancelled, Because token is null');
+    window.location.reload();
+  }
+  return config;
+});
+
+export default axiosInstance;

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -99,6 +99,5 @@ const AnalyticsOptionBtn = styled(button)<{ checked: boolean }>`
 `;
 
 const CategorySection = styled.section`
-  margin: 1.5rem 0 3rem;
-  padding-bottom: 7.5rem;
+  margin: 1.5rem 0;
 `;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -18,7 +18,6 @@ import { faSun, faMoon } from '@fortawesome/free-regular-svg-icons';
 import Backdrop from '../components/UI/Backdrop';
 import { PaymentManagerTitle } from '../components/anlytics/payment/PaymentManagerTitle';
 import { PaymentManagerHeader } from '../components/anlytics/payment/PaymentManagerHeader';
-import { PaymentManagerAddButton } from '../components/anlytics/payment/PaymentManagerAddButton';
 import {
   PaymentManagerCard,
   PaymentManagerCardWrapper,
@@ -42,6 +41,9 @@ export default function Home({ darkModeInput }: Props) {
   const { data: getPendingData } = useQuery(
     'getPending',
     getPendingTransactionAPI,
+    {
+      retry: false,
+    },
   );
 
   useEffect(() => {
@@ -61,8 +63,6 @@ export default function Home({ darkModeInput }: Props) {
   const PaymentManagerClickHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
   };
-
-  console.log(getPendingData);
 
   return (
     <Container>


### PR DESCRIPTION
문제 상황)
- 로그인 버튼 누르고, 메인 페이지에 들어갈 때 localStorage의 token이 정상적으로 초기화되지만, 이를 이전에 생성한 AxiosInstance 헤더에 반영하지 못해서 일어난 "Invalid token" 버그를 해결하였습니다.

해결부분 코드)
- 다음과 같이 axios interceptor로 요청을 가로채서, 만약 AxiosInstance headers에 Authorization 토큰이 들어가있지 않다면, 요청을 취소하고 페이지를 reload 했습니다. 
- 페이지를 reload하면 defaultClient.ts 파일에서 AxiosInstance를 새롭게 만들게 되고, 실제 토큰값을 참조할 수 있게되므로 버그가 고쳐집니다.


```typescript
axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
  if (!config.headers.Authorization) {
    source.cancel('Request cancelled, Because token is null');
    window.location.reload();
  }
  return config;
});
```